### PR TITLE
Update `NoISBNBook` Creation Validation to No Longer Require Author

### DIFF
--- a/svelte/src/lib/components/package/book/add-book.svelte
+++ b/svelte/src/lib/components/package/book/add-book.svelte
@@ -37,12 +37,7 @@
     return !inputISBN || (inputISBN.length !== 10 && inputISBN.length !== 13)
   }
   $: shouldDisableSearchNoISBN = () => {
-    return (
-      !inputTitle ||
-      !inputAuthor ||
-      inputTitle.trim().length === 0 ||
-      inputAuthor.trim().length === 0
-    )
+    return !inputTitle || inputTitle.trim().length === 0
   }
   $: loadISBN = () => {
     if (shouldDisableSearch()) return
@@ -53,7 +48,7 @@
     focusedBook.set({
       id: null,
       title: inputTitle,
-      authors: inputAuthor.split(',').map((a) => a.trim())
+      authors: inputAuthor?.split(',').map((a) => a.trim())
     })
     await focusedBook.sync()
     focusedPackage.addBook($focusedBook)

--- a/svelte/src/routes/invoice/[packageID]@print.svelte
+++ b/svelte/src/routes/invoice/[packageID]@print.svelte
@@ -14,6 +14,7 @@
   import logo from '$assets/invoice/invoice-logo.svg'
   import information from '$assets/invoice/invoice-information.svg'
   import Zine from '$components/zine/zine.svelte'
+  import Book from '$components/book.svelte'
 
   export let packageID: number
   export let print: boolean = false
@@ -97,7 +98,10 @@
       {/each}
       {#each $focusedPackage.noISBNBooks as book}
         <li>
-          <em>{book.title}</em> &mdash; {book.authors.join(', ')}
+          <em>{book.title}</em>
+          {#if book.authors && book.authors.length > 0}
+            &mdash; {book.authors.join(', ')}
+          {/if}
         </li>
       {/each}
     </ol>


### PR DESCRIPTION
Updates the validation logic when creating a new book with no ISBN to only require a Title. This is to address current staff concerns around adding items to packages which do not have an author (eg: Comics, Magazines)

https://user-images.githubusercontent.com/13069550/183329384-655c5b05-6cc4-4d18-bede-4761eeba1efc.mov


