### PR TITLE
Remove Database ID for Package from Package View

### DIFF
--- a/svelte/src/lib/components/package/package-table.svelte
+++ b/svelte/src/lib/components/package/package-table.svelte
@@ -91,8 +91,6 @@
                     (No ID available)
                   {/if}
                 </span>
-
-                &mdash; Package #{pbcPackage.id}
               </h2>
             {/if}
             <ul>


### PR DESCRIPTION
In the `search/packages` endpoint, removes the database ID of the package from the table

**Before**
<img width="821" alt="before" src="https://user-images.githubusercontent.com/13069550/183329772-a8039021-0c04-431f-88c6-3379fc245722.png">


**After**
<img width="821" alt="after" src="https://user-images.githubusercontent.com/13069550/183329789-e321c0f2-db79-4fe8-8f22-ccd424870ab1.png">

