### PR TITLE
[pamory] Fix Create Zine flow for Frontend

### DIFF
--- a/svelte/src/lib/stores/zine.ts
+++ b/svelte/src/lib/stores/zine.ts
@@ -40,8 +40,9 @@ export class ZineStore implements Writable<Zine[]> {
     try {
       const createdZine = await ZineService.createZine({
         id: null,
-        threeLetterCode,
+        code: threeLetterCode,
         title,
+        type: 'zine',
         inUse: true
       })
       this.fetch()

--- a/svelte/src/routes/admin.svelte
+++ b/svelte/src/routes/admin.svelte
@@ -8,8 +8,9 @@
   import SearchByBook from '$components/package/search/search-by-book.svelte'
   import { gotoPackageSearch } from '$util/routing'
 
-  const alertZineCreated = ({ detail: zine }) =>
-    alert(`Successfully added new Zine "${zine.threeLetterCode} - ${zine.title}"`)
+  const alertZineCreated = ({ detail: zine }) => {
+    alert(`Successfully added new Zine "${zine.code} - ${zine.title}"`)
+  }
   const alertFacilityCreated = ({ detail: facility }) =>
     alert(
       `Successfully added new Facility "[${facility.state}] ${facility.facility_name} - ${facility.facility_type}"`


### PR DESCRIPTION
[Pivotal Tracker #184251248](https://www.pivotaltracker.com/story/show/184251248)

Updates the "Create Zine" UI on `/admin` to use the correct endpoint and body for creating a zine with the new backend.